### PR TITLE
fix(release): adding conventional-changelog-conventionalcommits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "@semantic-release/github": "^10.1.3",
         "@semantic-release/npm": "^12.0.1",
         "@semantic-release/release-notes-generator": "^14.0.1",
+        "commitlint": "^19.3.0",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
         "gh-pages": "^6.1.1",
         "husky": "^9.1.4",
         "lint-staged": "^15.2.7",
@@ -2267,6 +2269,18 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -8369,6 +8383,22 @@
         "node": ">= 12"
       }
     },
+    "node_modules/commitlint": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/commitlint/-/commitlint-19.3.0.tgz",
+      "integrity": "sha512-B8eUVQCjz+1ZAjR3LC3+vzKg7c4/qN4QhSxkjp0u0v7Pi79t9CsnGAluvveKmFh56e885zgToPL5ax+l8BHTPg==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/cli": "^19.3.0",
+        "@commitlint/types": "^19.0.3"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -8498,15 +8528,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@semantic-release/github": "^10.1.3",
     "@semantic-release/npm": "^12.0.1",
     "@semantic-release/release-notes-generator": "^14.0.1",
+    "commitlint": "^19.3.0",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "gh-pages": "^6.1.1",
     "husky": "^9.1.4",
     "lint-staged": "^15.2.7",


### PR DESCRIPTION
Adding `conventional-changelog-conventionalcommits` to fix this error on `release`

<img width="1134" alt="Screenshot 2024-08-02 at 16 29 19" src="https://github.com/user-attachments/assets/e23c2f0d-dacf-45d4-aac5-eb65cf99cded">

https://github.com/geo-quest/travel-bingo/actions/runs/10217170800/job/28270341387