### PR TITLE
feat: add 404 redirect to index

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "scripts": {
     "prepare": "husky",
-    "start:local": "HOST=0.0.0.0 npm start",
-    "start": "react-scripts start",
+    "start:local": "PUBLIC_URL=/ HOST=0.0.0.0 npm start",
+    "start": "PUBLIC_URL=/ react-scripts start",
     "build": "react-scripts build",
     "lint": "npx eslint src",
     "lint:fix": "npx eslint src --fix",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Travel Bingo</title>
+    <script type="text/javascript">
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(pathSegmentsToKeep)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,16 +6,9 @@ import Game from "./pages/Game/Game";
 import Home from "./pages/Home/Home";
 import NoPage from "./pages/NoPage/NoPage";
 
-const getBasename = () => {
-  if (window.location.hostname === "geo-quest.github.io") {
-    return "/travel-bingo";
-  }
-  return "/";
-};
-
 function App() {
   return (
-    <BrowserRouter basename={getBasename()}>
+    <BrowserRouter basename={`/${process.env.PUBLIC_URL}`}>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/editions/:editionId" element={<Game />} />


### PR DESCRIPTION
Due to GitHub Pages not redirecting all routes to `/index.html`, client-side routing is not functional. Therefore, we are implementing a 404 page that redirects to the main `index.html` to ensure that routing is managed by our application.