### PR TITLE
feat(timeline): reversing timeline during the game

### DIFF
--- a/src/components/GameLeaderBoard/FinishedRun.tsx
+++ b/src/components/GameLeaderBoard/FinishedRun.tsx
@@ -1,7 +1,7 @@
 import { Col, Row, Space, Statistic, Tabs } from 'antd'
 import FormattedDate from 'components/Date/FormattedDate'
-import Events from 'components/Events/Events'
 import FallingEmojis from 'components/FallingEmojis/FallingEmojis'
+import Timeline from 'components/Timeline/Timeline'
 import {
   KeyObject,
   ResultEvent,
@@ -39,7 +39,7 @@ const FinishedRun = ({ game, run, state, events }: Props) => {
       key: '2',
       label: t('run.timeline'),
       children: (
-        <Events
+        <Timeline
           events={events}
           teamsData={run.teams}
           challenges={game.challenges}

--- a/src/components/GameLeaderBoard/StartedRun.tsx
+++ b/src/components/GameLeaderBoard/StartedRun.tsx
@@ -1,7 +1,7 @@
 import { Col, Row, Space, Statistic, Tabs } from 'antd'
 import FormattedDate from 'components/Date/FormattedDate'
 import RelativeDate from 'components/Date/RelativeDate'
-import Events from 'components/Events/Events'
+import Timeline from 'components/Timeline/Timeline'
 import {
   KeyObject,
   ResultEvent,
@@ -38,11 +38,12 @@ const StartedRun = ({ run, events, game }: Props) => {
       key: '2',
       label: t('run.timeline'),
       children: (
-        <Events
+        <Timeline
           events={events}
           teamsData={run.teams}
           challenges={game.challenges}
           filterFunction={event => event.type !== ResultEventType.Empty}
+          reverse
         />
       ),
     },

--- a/src/components/TeamResults/TeamResults.tsx
+++ b/src/components/TeamResults/TeamResults.tsx
@@ -1,15 +1,16 @@
 import { Col, Row, Space, Statistic, Tag, Typography } from 'antd'
 import BingoBoard from 'components/BingoBoard/BingoBoard'
 import ChallengeModal from 'components/ChallengeModal/ChallengeModal'
-import Events from 'components/Events/Events'
 import NoPage from 'components/NoPage/NoPage'
 import Rank from 'components/Rank/Rank'
 import Score from 'components/Score/Score'
+import Timeline from 'components/Timeline/Timeline'
 import {
   Challenge,
   KeyObject,
   ResultEventType,
   RunGameData,
+  RunGameStatus,
   TeamGameData,
   TravelBingoGameData,
 } from 'data/interfaces'
@@ -135,7 +136,7 @@ const TeamResults = ({ team, run, game }: Props) => {
       <Row>
         <Col span={24}>
           <Title level={2}>{t('run.timeline')}</Title>
-          <Events
+          <Timeline
             events={events}
             teamsData={run.teams}
             challenges={game.challenges}
@@ -145,6 +146,7 @@ const TeamResults = ({ team, run, game }: Props) => {
                 event.team === team.key ||
                 (event.type === ResultEventType.Curse && event.cursedTeam === team.key))
             }
+            reverse={state.status === RunGameStatus.Started}
           />
         </Col>
       </Row>

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -10,6 +10,7 @@ export interface Props {
   teamsData: TeamsGameData
   challenges: Challenge[][]
   filterFunction: (events: ResultEvent) => boolean
+  reverse?: boolean
 }
 
 interface TimelineEvent extends ResultEvent {
@@ -20,7 +21,7 @@ interface TimelineEvent extends ResultEvent {
   bingoEvents?: ResultEvent[]
 }
 
-const Events = ({ events, teamsData, challenges, filterFunction }: Props) => {
+export default ({ events, teamsData, challenges, filterFunction, reverse }: Props) => {
   const { t } = useTranslation()
 
   const getColorByEventType = (type: ResultEventType) => {
@@ -323,8 +324,13 @@ const Events = ({ events, teamsData, challenges, filterFunction }: Props) => {
     return timelineEvents
   }
 
-  const timelineItems = mergeItems(events.filter(filterFunction)).map(
-    (event: TimelineEvent, index: number) => ({
+  const timelineItems = mergeItems(events.filter(filterFunction))
+    .sort(
+      (a, b) =>
+        (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()) *
+        (reverse === true ? -1 : 1),
+    )
+    .map((event: TimelineEvent, index: number) => ({
       key: index,
       color: getColorByEventType(event.type),
       children: (
@@ -340,10 +346,7 @@ const Events = ({ events, teamsData, challenges, filterFunction }: Props) => {
           <div>{renderDetails(event)}</div>
         </div>
       ),
-    }),
-  )
+    }))
 
   return <Timeline items={timelineItems} />
 }
-
-export default Events


### PR DESCRIPTION
- renaming `components/Events` to `components/Timeline`
- adding reverse prop to the Timeline
- enabling new prop for running game

<img width="845" alt="Screenshot 2024-08-16 at 19 36 25" src="https://github.com/user-attachments/assets/2ffaf9b1-ea3d-4676-b234-39a9b9812b66">
<img width="828" alt="Screenshot 2024-08-16 at 19 36 03" src="https://github.com/user-attachments/assets/cbf81ad9-9f30-4586-90e3-0ca49ce30dbc">
